### PR TITLE
SM-1648 - remove orientation from exif data when picking photo from library

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -511,6 +511,7 @@ static NSString* toBase64(NSData* data) {
                             NSMutableDictionary *TIFFDictionary = [[metadata objectForKey:(NSString*)kCGImagePropertyTIFFDictionary]mutableCopy];
                             if (TIFFDictionary) {
                                 [self.metadata setObject:TIFFDictionary forKey:(NSString*)kCGImagePropertyTIFFDictionary];
+                                [[self.metadata valueForKey:(NSString*)kCGImagePropertyTIFFDictionary] removeObjectForKey:(NSString*)kCGImagePropertyTIFFOrientation];
                             }
                             
                             


### PR DESCRIPTION
The image is being reoriented before passing it ahead. 
Leaving the orientation tag behind is leading to wrong rendering of the image.